### PR TITLE
Optimized employment alignment

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -5,8 +5,8 @@ maxNumberOfRuns: 1
 executeWithGui: false
 randomSeed: 1821
 startYear: 2011
-endYear: 2040
-popSize: 170000
+endYear: 2013
+popSize: 20000
 
 # Arguments passed to the SimPathsModel
 model_args:

--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -930,6 +930,22 @@ public class Parameters {
 
     }
 
+    private static void addFixedCostRegressors(MultiKeyCoefficientMap map, List<String> regressors) {
+        for (String reg : regressors) {
+            if ((reg.equals("AlignmentFixedCostMen") || reg.equals("AlignmentFixedCostWomen"))
+                    && map.getValue(reg) == null) {
+                // Infer the format from an existing coefficient
+                Object sample = map.getValue("IncomeDiv100");
+                if (sample instanceof Object[]) {
+                    map.putValue(reg, new Object[]{0.0});
+                } else {
+                    map.putValue(reg, 0.0);
+                }
+            }
+        }
+    }
+
+
     public static void defineCountryString(Country country) {COUNTRY_STRING  =country.toString(); }
 
     /**
@@ -1218,13 +1234,27 @@ public class Parameters {
         coeffCovarianceWagesFemalesNE = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_wages.xlsx"), "Wages_FemalesNE", 1, columnsWagesFemalesNE);
 
         //Labour Supply utility function coefficients
-        coeffLabourSupplyUtilityMales = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"), "Single_male", 1, columnsLabourSupplyUtilityMales);
-        coeffLabourSupplyUtilityFemales = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"), "Single_female", 1, columnsLabourSupplyUtilityFemales);
-        coeffLabourSupplyUtilityMalesWithDependent = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"), "SingleDep_Males", 1, columnsLabourSupplyUtilityMalesWithDependent);
-        coeffLabourSupplyUtilityFemalesWithDependent = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"), "SingleDep_Females", 1, columnsLabourSupplyUtilityFemalesWithDependent);
-        coeffLabourSupplyUtilityACMales = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"), "SingleAC_Males", 1, columnsLabourSupplyUtilityACMales);
-        coeffLabourSupplyUtilityACFemales = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"), "SingleAC_Females", 1, columnsLabourSupplyUtilityACFemales);
-        coeffLabourSupplyUtilityCouples = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"), "Couples", 1, columnsLabourSupplyUtilityCouples);
+        coeffLabourSupplyUtilityMales = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"),"Single_male", 1, columnsLabourSupplyUtilityMales);
+        addFixedCostRegressors(coeffLabourSupplyUtilityMales,List.of("AlignmentFixedCostMen"));
+
+        coeffLabourSupplyUtilityFemales = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"),"Single_female", 1, columnsLabourSupplyUtilityFemales);
+        addFixedCostRegressors(coeffLabourSupplyUtilityFemales,List.of("AlignmentFixedCostWomen"));
+
+        coeffLabourSupplyUtilityMalesWithDependent = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"),"SingleDep_Males", 1, columnsLabourSupplyUtilityMalesWithDependent);
+        addFixedCostRegressors(coeffLabourSupplyUtilityMalesWithDependent,List.of("AlignmentFixedCostMen"));
+
+        coeffLabourSupplyUtilityFemalesWithDependent = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"),"SingleDep_Females", 1, columnsLabourSupplyUtilityFemalesWithDependent);
+        addFixedCostRegressors(coeffLabourSupplyUtilityFemalesWithDependent,List.of("AlignmentFixedCostWomen"));
+
+        coeffLabourSupplyUtilityACMales =ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"),"SingleAC_Males", 1, columnsLabourSupplyUtilityACMales);
+        addFixedCostRegressors(coeffLabourSupplyUtilityACMales,List.of("AlignmentFixedCostMen"));
+
+        coeffLabourSupplyUtilityACFemales =ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"),"SingleAC_Females", 1, columnsLabourSupplyUtilityACFemales);
+        addFixedCostRegressors(coeffLabourSupplyUtilityACFemales,List.of("AlignmentFixedCostWomen"));
+
+        coeffLabourSupplyUtilityCouples =ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_labourSupplyUtility.xlsx"),"Couples", 1, columnsLabourSupplyUtilityCouples);
+        addFixedCostRegressors(coeffLabourSupplyUtilityCouples,List.of("AlignmentFixedCostMen", "AlignmentFixedCostWomen"));
+
 
         //Heckman model employment selection
         coeffCovarianceEmploymentSelectionMalesE = ExcelAssistant.loadCoefficientMap(resolveCountryFile(country, "reg_employmentSelection.xlsx"), "EmploymentSelection_MaleE", 1, columnsEmploymentSelectionMalesE);

--- a/src/main/java/simpaths/model/ActivityAlignmentV2.java
+++ b/src/main/java/simpaths/model/ActivityAlignmentV2.java
@@ -80,9 +80,9 @@ public class ActivityAlignmentV2 implements IEvaluation {
                 // Infer the format from an existing coefficient
                 Object sample = map.getValue("IncomeDiv100");
                 if (sample instanceof Object[]) {
-                    map.replaceValue(reg, new Object[]{0.0});
+                    map.putValue(reg, new Object[]{0.0});
                 } else {
-                    map.replaceValue(reg, 0.0);
+                    map.putValue(reg, 0.0);
                 }
             }
         }
@@ -133,10 +133,14 @@ public class ActivityAlignmentV2 implements IEvaluation {
             coefficientMap.replaceValue(reg, newVal);
         }
         // Update all benefit units in parallel for efficiency
-        benefitUnits.parallelStream().forEach(bu -> {
-            bu.updateLabourFast();
-            //bu.updateLabourSupplyAndIncome();
-            bu.updateActivityOfPersonsWithinBenefitUnit();
+        // Update only benefit units in this subgroup
+        benefitUnits.parallelStream()
+                .filter(this::matchesSubgroup)
+                .forEach(bu -> {
+                    bu.updateLabourBypassUtilityComputation();
+                    //bu.updateLabourFast();
+                    //bu.updateLabourSupplyAndIncome();
+                    bu.updateActivityOfPersonsWithinBenefitUnit();
         });
     }
 

--- a/src/main/java/simpaths/model/LabourMarket.java
+++ b/src/main/java/simpaths/model/LabourMarket.java
@@ -68,8 +68,10 @@ public class LabourMarket {
                 }
             }
 
-            if (model.isAlignEmployment() && model.getYear() <= EMPLOYMENT_ALIGNMENT_END_YEAR & !model.isMacroShocksOn()) {
+            if (model.isAlignEmployment() && model.getYear() <= EMPLOYMENT_ALIGNMENT_END_YEAR && !model.isMacroShocksOn()) {
                 benefitUnits.parallelStream().forEach(BenefitUnit::updateLabourChoices);
+                benefitUnits.parallelStream().forEach(BenefitUnit::updateUtilityRegressionScores);
+
                 model.activityAlignmentSingleMales();
                 model.activityAlignmentSingleACMales();
                 model.activityAlignmentSingleFemales();
@@ -77,8 +79,6 @@ public class LabourMarket {
                 model.activityAlignmentCouples();
                 model.activityAlignmentMaleWithDependents();
                 model.activityAlignmentFemaleWithDependents();
-
-
             }
 
             if (model.isMacroShocksOn()) {


### PR DESCRIPTION
-Hoisting utility computation out of the alignment loop via new method `computeUtilityRegressionScoreWithoutFC()` 
-Fixing benefit-unit filtering in `ActivityAlignmentV2`