### PR TITLE
Optimized output storage and fixed country bug in singleRun

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -6,7 +6,7 @@ executeWithGui: false
 randomSeed: 1821
 startYear: 2011
 endYear: 2013
-popSize: 20000
+popSize: 30000
 
 # Arguments passed to the SimPathsModel
 model_args:

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -2,6 +2,8 @@
 package simpaths.experiment;
 
 // import Java packages
+import microsim.data.db.DatabaseUtils;
+import microsim.data.db.Experiment;
 import org.apache.log4j.Level;
 import org.apache.commons.cli.*;
 import org.yaml.snakeyaml.Yaml;
@@ -24,6 +26,7 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 import java.io.*;
+import microsim.data.ExperimentManager;
 
 
 public class SimPathsMultiRun extends MultiRun {
@@ -98,6 +101,12 @@ public class SimPathsMultiRun extends MultiRun {
 			return;
 		}
 		country = Country.getCountryFromNameString(countryString);
+
+        /*comment these lines if input folder needs to be saved in output*/
+        // Disable copying input folders into output
+        ExperimentManager.getInstance().copyInputFolderStructure = false;
+        // Ensure database files are loaded from the correct input directory
+        DatabaseUtils.databaseInputUrl = Experiment.inputFolder + File.separator + "input";
 
 		if (flagDatabaseSetup) {
 

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -275,6 +275,8 @@ public class SimPathsStart implements ExperimentBuilder {
 		Parameters.loadTimeSeriesFactorMaps(country);
 		Parameters.instantiateAlignmentMaps();
 
+        // define country string for Parameters
+        Parameters.defineCountryString(country);
 		// set-up database
 		Parameters.databaseSetup(country, showGui, startYear);
 	}

--- a/src/main/java/simpaths/model/SimPathsModel.java
+++ b/src/main/java/simpaths/model/SimPathsModel.java
@@ -171,7 +171,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
 
     private boolean alignCohabitation = true; //Set to true to align share of couples (cohabiting individuals)
 
-    private boolean alignEmployment = true; //true; //Set to true to align employment share
+    private boolean alignEmployment = false; //true; //Set to true to align employment share
 
     public boolean addRegressionStochasticComponent = true; //If set to true, and regression contains ResStanDev variable, will evaluate the regression score including stochastic part, and omits the stochastic component otherwise.
 
@@ -2221,7 +2221,7 @@ public class SimPathsModel extends AbstractSimulationManager implements EventLis
 
             // save to processed repository
             System.out.println("Saving compiled input data for future reference");
-    //        persistProcessed();
+            persistProcessed();
 
             stopwatch.stop();
             System.out.println("Time elapsed " + stopwatch.getTime()/1000 + " seconds");


### PR DESCRIPTION
-uncommenting `persistProcessed()` speeds up consequent simulations using MultiRun 
-removed exporting of the input folder to output to save storage space