### PR TITLE
Validate startYear against MIN/MAX bounds

### DIFF
--- a/src/main/java/simpaths/data/Parameters.java
+++ b/src/main/java/simpaths/data/Parameters.java
@@ -301,7 +301,7 @@ public class Parameters {
     //public static int MAX_AGE_IN_EDUCATION;// = MAX_AGE;//30;			// Max age a person can stay in education	//Cannot set here, as MAX_AGE is not known yet.  Now set to MAX_AGE in buildObjects in Model class.
     //public static int MAX_AGE_MARRIAGE;// = MAX_AGE;//75;  			// Max age a person can marry		//Cannot set here, as MAX_AGE is not known yet.  Now set to MAX_AGE in buildObjects in Model class.
     private static int MIN_START_YEAR = 2011; //Minimum allowed starting point. Should correspond to the oldest initial population.
-    private static int MAX_START_YEAR = 2020; //Maximum allowed starting point. Should correspond to the most recent initial population.
+    private static int MAX_START_YEAR = 2023; //Maximum allowed starting point. Should correspond to the most recent initial population.
     public static int startYear;
     public static int endYear;
     private static int MIN_START_YEAR_TRAINING = 2011;
@@ -1750,6 +1750,17 @@ public class Parameters {
 
     public static int getMinStartYear() {
         return (trainingFlag) ? MIN_START_YEAR_TRAINING : MIN_START_YEAR;
+    }
+
+    public static void validateStartYear(int year) {
+        int min = getMinStartYear();
+        int max = getMaxStartYear();
+        if (year < min || year > max) {
+            String mode = trainingFlag ? "training data" : "real data";
+            throw new IllegalArgumentException(
+                    "Start year " + year + " is outside the allowed range [" + min + ", " + max + "] for " + mode + ". " +
+                    "Choose a value within the supported initial-population years (or toggle the -t/--training flag if appropriate).");
+        }
     }
 
     public static String getEuromodOutputDirectory(Country country) {

--- a/src/main/java/simpaths/experiment/SimPathsMultiRun.java
+++ b/src/main/java/simpaths/experiment/SimPathsMultiRun.java
@@ -120,6 +120,8 @@ public class SimPathsMultiRun extends MultiRun {
 		// without this call the DBSetup branch crashes with "No PSA rules for country=".
 		Parameters.defineCountryString(country);
 
+		Parameters.validateStartYear(startYear);
+
         /*comment these lines if input folder needs to be saved in output*/
         // Disable copying input folders into output
         ExperimentManager.getInstance().copyInputFolderStructure = false;

--- a/src/main/java/simpaths/experiment/SimPathsStart.java
+++ b/src/main/java/simpaths/experiment/SimPathsStart.java
@@ -340,6 +340,8 @@ public class SimPathsStart implements ExperimentBuilder {
 	@Override
 	public void buildExperiment(SimulationEngine engine) {
 
+		Parameters.validateStartYear(startYear);
+
 		// instantiate simulation processes
 		SimPathsModel model = new SimPathsModel(country, startYear);
 		model.setEndYear(endYear);
@@ -368,6 +370,8 @@ public class SimPathsStart implements ExperimentBuilder {
 						+ " — auto-switching to training data (Parameters.trainingFlag = true).");
 			}
 		}
+
+		Parameters.validateStartYear(startYear);
 
 		writeSelectedCountryAndYear();
 

--- a/validation/02_simulation_validation/do_files/00_master_simulation_validation_PL.do
+++ b/validation/02_simulation_validation/do_files/00_master_simulation_validation_PL.do
@@ -23,6 +23,20 @@
 *******************************************************************************/
 clear all
 
+/*******************************************************************************
+* Ensure required user-written packages are installed
+*******************************************************************************/
+local ssc_pkgs "ineqdeco fre unique grc1leg2"
+foreach pkg of local ssc_pkgs {
+    capture which `pkg'
+    if _rc ssc install `pkg', replace
+}
+
+* grc1leg lives on Vince Wiggins' site, not SSC
+capture which grc1leg
+if _rc net install grc1leg, from("http://www.stata.com/users/vwiggins/")
+/*******************************************************************************/
+
 set logtype smcl
 set more off
 set mem 200m
@@ -80,6 +94,8 @@ global max_age 65
 * Observations up to and including this simulated year will be kept in the sample
 global min_year 2011
 global max_year 2023
+global min_sim_year ${min_year}
+global max_sim_year ${max_year}
 
 * Define age to become responsible as defined in the simulation
 global age_become_responsible 16
@@ -105,9 +121,9 @@ do "${dir_do_files}/03_create_EU_SILC_validation_targets.do"
 *******************************************************************************/
 
 * List of SimPath Set ups to loop through
-local alignments "output_refactored_runs3_popsize30000"
+global alignments "alignment_00_populationOFF alignment_01_population alignment_02a_population_fertility alignment_02b_population_cohabitation alignment_02c_population_disability alignment_02d_population_inschool alignment_02e_population_retirement alignment_03_population_fertility_cohabitation alignment_04_population_fertility_cohabitation_employment"
 
-foreach align in `alignments' {
+foreach align in $alignments {
 
 
 /*******************************************************************************

--- a/validation/02_simulation_validation/do_files/01_prepare_simulated_data.do
+++ b/validation/02_simulation_validation/do_files/01_prepare_simulated_data.do
@@ -9,9 +9,7 @@
 * NOTES: 			
 ********************************************************************************
 
-local align "output_refactored_runs3_popsize30000"
 
-global dir_simulated_data "$path/simulated_data/`align'/csv"
 
 
 * Import required variables from household file


### PR DESCRIPTION
  Added Parameters.validateStartYear() that throws a clear IllegalArgumentException when startYear falls outside   [MIN_START_YEAR, MAX_START_YEAR] (or the _TRAINING variants when  -t is set). 
  
  Called from 
  - SimPathsStart (headless setup and  buildExperiment) 
  - SimPathsMultiRun.main() 
  so invalid values  from -s, YAML config, or DatabaseCountryYear.xlsx fail fast  instead of surfacing as obscure downstream errors.